### PR TITLE
Hotfix/add base url as method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `guardian-php-sdk` will be documented in this file.
 
+
+## 1.0.1 2022-08-30
+
+- Add Guardian Base Url as a method
 ## 1.0.0 2022-08-25
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ composer require dovuofficial/guardian-php-sdk
 ```php
 $sdk = new Dovu\GuardianPhpSdk();
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('hmac_secret');
 
 $response = $sdk->accounts->create('username','password');

--- a/scripts/1-create-user.php
+++ b/scripts/1-create-user.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->create('jon', 'secret');

--- a/scripts/10-policies-trustchain.php
+++ b/scripts/10-policies-trustchain.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $authority = $sdk->accounts->login('dovuauthority', 'secret');

--- a/scripts/2-add-role.php
+++ b/scripts/2-add-role.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/3-register-application.php
+++ b/scripts/3-register-application.php
@@ -20,6 +20,8 @@ $document = '{
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/4-approve-register.php
+++ b/scripts/4-approve-register.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/5-project-submission.php
+++ b/scripts/5-project-submission.php
@@ -34,6 +34,8 @@ $document = '{
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/6-approve-farm-submission.php
+++ b/scripts/6-approve-farm-submission.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/7-mrv-agrecalc-submission.php
+++ b/scripts/7-mrv-agrecalc-submission.php
@@ -27,6 +27,8 @@ $document = '{
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/7-mrv-coolfarm-submission.php
+++ b/scripts/7-mrv-coolfarm-submission.php
@@ -17,6 +17,8 @@ $document = '{
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/scripts/8-create-verifier.php
+++ b/scripts/8-create-verifier.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->create('verifier', 'secret');

--- a/scripts/9-approve-agecalc.php
+++ b/scripts/9-approve-agecalc.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 

--- a/scripts/9-approve-coolfarm.php
+++ b/scripts/9-approve-coolfarm.php
@@ -8,6 +8,8 @@ $policyId = '62fcc7e54d3979bff880545f';
 
 $sdk = new DovuGuardianAPI;
 
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
 $sdk->setHmacSecret('1234567890');
 
 $user = $sdk->accounts->login('jon', 'secret');

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -28,7 +28,6 @@ class BaseAPIClient
         $this->apiToken = $apiToken;
     }
 
-
     public function setGuardianBaseUrl(string $url)
     {
         $this->baseUrl = $url;
@@ -136,6 +135,7 @@ class BaseAPIClient
     private function getConfigFromFile()
     {
         $path = dirname(__DIR__, 1);
+
         return include $path . "/config/app.php";
     }
 }

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -16,8 +16,6 @@ class BaseAPIClient
     public function __construct()
     {
         $this->config = $this->getConfigFromFile();
-
-        $this->base_uri = $this->config['app']['base_url'];
     }
 
     /**
@@ -28,6 +26,12 @@ class BaseAPIClient
     public function setApiToken(string $apiToken)
     {
         $this->apiToken = $apiToken;
+    }
+
+
+    public function setGuardianBaseUrl(string $url)
+    {
+        $this->baseUrl = $url;
     }
 
     /**
@@ -48,8 +52,8 @@ class BaseAPIClient
     public function get(string $uri)
     {
         $client = HttpClient::get()
-                    ->withBaseUri($this->base_uri)
-                    ->withHmac($this->base_uri.$uri, [], $this->hmacSecret);
+                    ->withBaseUri($this->baseUrl)
+                    ->withHmac($this->baseUrl.$uri, [], $this->hmacSecret);
 
         $client->setApiToken($this->apiToken);
 
@@ -65,9 +69,9 @@ class BaseAPIClient
     public function post(string $uri, array $payload = [])
     {
         $client = HttpClient::post()
-                    ->withBaseUri($this->base_uri)
+                    ->withBaseUri($this->baseUrl)
                     ->withBody(['form_params' => $payload])
-                    ->withHmac($this->base_uri.$uri, $payload, $this->hmacSecret);
+                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
 
 
         $client->setApiToken($this->apiToken);
@@ -84,9 +88,9 @@ class BaseAPIClient
     public function postJson(string $uri, $payload)
     {
         $client = HttpClient::post()
-                    ->withBaseUri($this->base_uri)
+                    ->withBaseUri($this->baseUrl)
                     ->withBody(['json' => $payload])
-                    ->withHmac($this->base_uri.$uri, $payload, $this->hmacSecret);
+                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
 
         $client->setApiToken($this->apiToken);
 
@@ -102,9 +106,9 @@ class BaseAPIClient
     public function put(string $uri, array $payload = [])
     {
         $client = HttpClient::put()
-                    ->withBaseUri($this->base_uri)
+                    ->withBaseUri($this->baseUrl)
                     ->withBody(['form_params' => $payload])
-                    ->withHmac($this->base_uri.$uri, $payload, $this->hmacSecret);
+                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
 
         $client->setApiToken($this->apiToken);
 
@@ -131,6 +135,7 @@ class BaseAPIClient
      */
     private function getConfigFromFile()
     {
-        return include "./config/app.php";
+        $path = dirname(__DIR__, 1);
+        return include $path . "/config/app.php";
     }
 }

--- a/src/Service/PolicyService.php
+++ b/src/Service/PolicyService.php
@@ -65,5 +65,4 @@ class PolicyService extends AbstractService
     {
         return $this->client->get("policies/{$policyId}/trustchains");
     }
-
 }

--- a/tests/PolicyIntegrationTest.php
+++ b/tests/PolicyIntegrationTest.php
@@ -80,6 +80,9 @@ dataset('coolfarm_mrv', [
  */
 it('SDK can process a given policy', function ($registration, $ecological_project, $agrecalc_mrv, $coolfarm_mrv) {
     $sdk = new DovuGuardianAPI();
+
+    $sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
     $sdk->setHmacSecret($sdk->config['local']['hmac_secret']);
 
     // Step One is generating a user.

--- a/tests/PolicyIntegrationTest.php
+++ b/tests/PolicyIntegrationTest.php
@@ -167,7 +167,4 @@ it('SDK can process a given policy', function ($registration, $ecological_projec
     $sdk->setApiToken($registry_token);
 
     $trustchain = $sdk->policies->trustchain($policy_id);
-
-
-
 })->with('registration', 'ecological_project', 'agrecalc_mrv', 'coolfarm_mrv');


### PR DESCRIPTION
Changed config base url to be added as a method using (as an example):

$sdk->setGuardianBaseUrl('http://localhost:3001/api/');

Updated CHANGELOG and README.