### PR TITLE
Add policy token id fetch

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -12,7 +12,7 @@ return [
     ],
 
     'local' => [
-        'policy_id' => '62fcc7e54d3979bff880545f',
+        'policy_id' => '632b33532e11b6094416fc14',
         'hmac_secret' => '1234567890',
     ],
 

--- a/scripts/test-policy-token.php
+++ b/scripts/test-policy-token.php
@@ -1,0 +1,30 @@
+<?php
+
+require('./vendor/autoload.php');
+
+use Dovu\GuardianPhpSdk\DovuGuardianAPI;
+
+$policyId = '632b33532e11b6094416fc14';
+
+$sdk = new DovuGuardianAPI;
+
+$sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
+$sdk->setHmacSecret('1234567890');
+
+$user = $sdk->accounts->login('dovuauthority', 'secret');
+
+$sdk->setApiToken($user['data']['accessToken']);
+
+$token = $sdk->policies->token($policyId);
+
+dd($token);
+
+
+
+
+
+
+
+
+

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -8,7 +8,6 @@ use Dovu\GuardianPhpSdk\Exceptions\UnauthorizedException;
 use Dovu\GuardianPhpSdk\Exceptions\ValidationException;
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpClient
@@ -27,7 +26,7 @@ class HttpClient
     {
         $payload = $this->body ?? null;
 
-        if (!empty($this->hmac)) {
+        if (! empty($this->hmac)) {
             $payload['headers'] = [
                 'x-date' => $this->hmac['x-date'],
                 'x-signature' => $this->hmac['x-signature'],
@@ -53,7 +52,6 @@ class HttpClient
         $responseBody = (string) $response->getBody();
 
         return json_decode($responseBody, true) ?: $responseBody;
-      
     }
 
     /**

--- a/src/Service/PolicyService.php
+++ b/src/Service/PolicyService.php
@@ -69,4 +69,14 @@ class PolicyService extends AbstractService
 
         return $this->client->get("policies/{$policyId}/trustchains");
     }
+
+    /**
+     *
+     * @param string $policyId
+     * @return void
+     */
+    public function token(string $policyId)
+    {
+        return $this->client->get("policies/{$policyId}/token");
+    }
 }

--- a/src/Service/PolicyService.php
+++ b/src/Service/PolicyService.php
@@ -63,7 +63,7 @@ class PolicyService extends AbstractService
      */
     public function trustChain(?string $policyId)
     {
-        if($policyId === null){
+        if ($policyId === null) {
             return [];
         }
 

--- a/tests/PolicyTokenTest.php
+++ b/tests/PolicyTokenTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Dovu\GuardianPhpSdk\DovuGuardianAPI;
+
+it('SDK can get a token for a policy', function () {
+    $sdk = new DovuGuardianAPI();
+
+    $sdk->setGuardianBaseUrl('http://localhost:3001/api/');
+
+    $sdk->setHmacSecret($sdk->config['local']['hmac_secret']);
+
+    $registry = $sdk->accounts->login('dovuauthority', 'secret');
+
+    $sdk->setApiToken($registry['data']['accessToken']);
+
+    $policy_id = $sdk->config['local']['policy_id'];
+
+    $token = $sdk->policies->token($policy_id);
+
+    expect($token["data"]["policy_token_id"])->toBeTruthy();
+});


### PR DESCRIPTION
## Why should we care?

We need a simple call to fetch the token id from the policy so that we can inject it into an instance of a ProjectPolicy, when carbon is sold on the marketplace we have a direct reference to the token ID for any transfers.

## Additions

This is the new call on the SDK, it returns the same object from the API where the data payload has a single field of "policy_token_id", you can see how to access these items from the attached tests and scripts.

```
$sdk->policies->token($policy_id)
```