### PR TITLE
Added Notifictions functionality + code refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "pestphp/pest": "^1.20",
-        "spatie/ray": "^1.28"
+        "spatie/ray": "^1.28",
+        "symfony/var-dumper": "^6.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/app.php
+++ b/config/app.php
@@ -20,7 +20,7 @@ return [
         'accounts' => AccountService::class,
         'policies' => PolicyService::class,
         'mrv' => MrvService::class,
-    ]
+    ],
 
 ];
 

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -45,10 +45,9 @@ class BaseAPIClient
         $this->hmacSecret = $secret;
     }
 
-
     /**
      *
-     * @param boolean $errors
+     * @param bool $errors
      * @return void
      */
     public function setThrowErrors(bool $errors = true): void

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -2,17 +2,15 @@
 
 namespace Dovu\GuardianPhpSdk;
 
-use Dovu\GuardianPhpSdk\HttpClient\HttpClient;
+// use Dovu\GuardianPhpSdk\HttpClient\HttpClient;
 
 class BaseAPIClient
 {
-    /** @var string */
     public string $apiToken = "";
-
     public string $hmacSecret = "";
-
+    public string $baseUrl;
     public bool $throwErrors = true;
-
+    public array $notifications = [];
     public array $config = [];
 
     public function __construct()
@@ -20,131 +18,41 @@ class BaseAPIClient
         $this->config = $this->getConfigFromFile();
     }
 
-    /**
-     *
-     * @param string $apiToken
-     * @return void
-     */
-    public function setApiToken(string $apiToken)
+
+
+    public function setApiToken(string $apiToken): void
     {
         $this->apiToken = $apiToken;
     }
 
-    public function setGuardianBaseUrl(string $url)
+
+
+    public function setGuardianBaseUrl(string $url): void
     {
         $this->baseUrl = $url;
     }
 
-    /**
-     *
-     * @param string $secret
-     * @return void
-     */
-    public function setHmacSecret(string $secret)
+
+
+    public function setHmacSecret(string $secret): void
     {
         $this->hmacSecret = $secret;
     }
 
-    /**
-     *
-     * @param bool $errors
-     * @return void
-     */
+
     public function setThrowErrors(bool $errors = true): void
     {
         $this->throwErrors = $errors;
     }
 
-    /**
-     *
-     * @param string $uri
-     * @return void
-     */
-    public function get(string $uri)
+    
+    public function addNotification(array $notification)
     {
-        $client = HttpClient::get()
-                    ->withBaseUri($this->baseUrl)
-                    ->withHmac($this->baseUrl.$uri, [], $this->hmacSecret);
-
-        $client->setApiToken($this->apiToken);
-
-        return $client->request($uri);
+        $this->notifications[] = $notification;
     }
 
-    /**
-     *
-     * @param string $uri
-     * @param array $payload
-     * @return void
-     */
-    public function post(string $uri, array $payload = [])
-    {
-        $client = HttpClient::post()
-                    ->withBaseUri($this->baseUrl)
-                    ->withBody(['form_params' => $payload])
-                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
 
-
-        $client->setApiToken($this->apiToken);
-
-        return $client->request($uri);
-    }
-
-    /**
-     *
-     * @param string $uri
-     * @param [type] $payload
-     * @return void
-     */
-    public function postJson(string $uri, $payload)
-    {
-        $client = HttpClient::post()
-                    ->withBaseUri($this->baseUrl)
-                    ->withBody(['json' => $payload])
-                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
-
-        $client->setApiToken($this->apiToken);
-
-        return $client->request($uri);
-    }
-
-    /**
-     *
-     * @param string $uri
-     * @param array $payload
-     * @return void
-     */
-    public function put(string $uri, array $payload = [])
-    {
-        $client = HttpClient::put()
-                    ->withBaseUri($this->baseUrl)
-                    ->withBody(['form_params' => $payload])
-                    ->withHmac($this->baseUrl.$uri, $payload, $this->hmacSecret);
-
-        $client->setApiToken($this->apiToken);
-
-        return $client->request($uri);
-    }
-
-    /**
-     *
-     * @param [type] $response
-     * @return bool
-     */
-    public function isSuccessful($response): bool
-    {
-        if (! $response) {
-            return false;
-        }
-
-        return (int) substr($response->getStatusCode(), 0, 1) === 2;
-    }
-
-    /**
-     *
-     * @return void
-     */
-    private function getConfigFromFile()
+    private function getConfigFromFile(): array
     {
         $path = dirname(__DIR__, 1);
 

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -11,6 +11,8 @@ class BaseAPIClient
 
     public string $hmacSecret = "";
 
+    public bool $throwErrors = true;
+
     public array $config = [];
 
     public function __construct()
@@ -41,6 +43,17 @@ class BaseAPIClient
     public function setHmacSecret(string $secret)
     {
         $this->hmacSecret = $secret;
+    }
+
+
+    /**
+     *
+     * @param boolean $errors
+     * @return void
+     */
+    public function setThrowErrors(bool $errors = true): void
+    {
+        $this->throwErrors = $errors;
     }
 
     /**

--- a/src/Contracts/HmacInterface.php
+++ b/src/Contracts/HmacInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Dovu\GuardianPhpSdk\Contracts;
+
+interface HmacInterface
+{
+    public function get(): array;
+}

--- a/src/Contracts/HttpClientInterface.php
+++ b/src/Contracts/HttpClientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dovu\GuardianPhpSdk\Contracts;
+
+use Exception;
+
+interface HttpClientInterface
+{
+    public function get(string $uri): array|Exception;
+
+    public function post(string $uri, array $payload = [], bool $jsonRequest = false):  array|Exception;
+    
+    public function put(string $uri, array $payload = []):  array|Exception;
+}

--- a/src/HttpClient/Hmac.php
+++ b/src/HttpClient/Hmac.php
@@ -11,8 +11,9 @@ class Hmac
     private array  $url;
     private string $hashedBody;
     private string $signature;
+    private static Hmac $instance;
 
-    public function __construct(
+    public function create(
         string $method,
         string $url,
         array  $body = [],
@@ -43,6 +44,15 @@ class Hmac
             'x-content-sha256' => $this->hashedBody,
             'x-signature' => $this->signature,
         ];
+    }
+
+    public static function getInstance(): Hmac
+    {
+        if(empty(self::$instance)) {
+            self::$instance = new Hmac();
+        }
+
+        return self::$instance;
     }
 
     /**

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -66,10 +66,8 @@ class HttpClient
         if (is_null($body)) {
             return $res;
         }
-        
-        return array_merge($res, $body);
-        
 
+        return array_merge($res, $body);
     }
 
     /**
@@ -84,10 +82,10 @@ class HttpClient
 
     /**
      *
-     * @param boolean $throwErrors
+     * @param bool $throwErrors
      * @return void
      */
-    public function setThrowErrors(bool $throwErrors) : void
+    public function setThrowErrors(bool $throwErrors): void
     {
         $this->throwErrors = $throwErrors;
     }
@@ -194,8 +192,7 @@ class HttpClient
      */
     public static function __callStatic(string $method, array $args): mixed
     {
-
-        if (!in_array($method, self::$methods)) {
+        if (! in_array($method, self::$methods)) {
             throw new Exception('The method ' . $method . ' is not supported.');
         }
 

--- a/src/Notifications/AbstractNotifier.php
+++ b/src/Notifications/AbstractNotifier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dovu\GuardianPhpSdk\Notifications;
+
+use Exception;
+
+abstract class AbstractNotifier
+{
+    public static function getNotifier($notification): AbstractNotifier
+    {
+        $notifier = array_keys($notification)[0];
+
+        return match ($notifier) {
+            'slack' =>  new SlackNotifier($notification[$notifier]),
+        };
+        
+    }
+
+    abstract public function send(Exception $error): void;
+}

--- a/src/Notifications/NotificationManager.php
+++ b/src/Notifications/NotificationManager.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dovu\GuardianPhpSdk\Notifications;
+
+class NotificationManager
+{
+    public function __construct(private $settings)
+    {
+        
+    }
+
+    public function register(\Exception $error)
+    {
+        foreach($this->settings->notifications as $notification){
+            $notifier = AbstractNotifier::getNotifier($notification);
+            $notifier->send($error);
+        }
+    }
+}

--- a/src/Notifications/SlackNotifier.php
+++ b/src/Notifications/SlackNotifier.php
@@ -6,8 +6,6 @@ use Exception;
 
 class SlackNotifier extends AbstractNotifier
 {
-    const SLACK_WEBHOOK = "https://hooks.slack.com/services/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";
-
     public function __construct(private $webhook)
     {
         

--- a/src/Notifications/SlackNotifier.php
+++ b/src/Notifications/SlackNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Dovu\GuardianPhpSdk\Notifications;
+
+use Exception;
+
+class SlackNotifier extends AbstractNotifier
+{
+    const SLACK_WEBHOOK = "https://hooks.slack.com/services/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";
+
+    public function __construct(private $webhook)
+    {
+        
+    }
+
+    public function send(Exception $error): void
+    {
+        $message = json_decode($error->getMessage(), true);
+
+        $c = curl_init($this->webhook);
+        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($c, CURLOPT_POST, true);
+        curl_setopt($c, CURLOPT_POSTFIELDS, $this->formatMessage($message));
+        curl_exec($c);
+        curl_close($c);
+    }
+
+
+    private function formatMessage($errorMessage): array
+    {
+        $code = $errorMessage['error']['statusCode'];
+        $message = $errorMessage['error']['message'];
+        $timestamp = $errorMessage['error']['timestamp'];
+        $path = $errorMessage['error']['path'];
+
+        return ['payload' => '{
+            "text": "A Guardian request error has occurred:",
+            "attachments": [{
+            "color": "#f2c744",
+            "blocks":
+                [
+                    {
+                        "type": "section",
+                                "text": 
+                                    {
+                                        "type": "mrkdwn",
+                                         "text": "*Status Code:* '.$code.'\n*Message:* '.$message.'\n*Timestamp:* '.$timestamp.'\n*Path:* '.$path.'"
+                                    },
+                                
+                    },
+                    
+                ]
+            }]
+        }'];
+    }
+}

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -2,14 +2,10 @@
 
 namespace Dovu\GuardianPhpSdk\Service;
 
+use Dovu\GuardianPhpSdk\Contracts\HttpClientInterface;
+
 class AbstractService
 {
-    protected $client;
-
-    protected $config = [];
-
-    public function __construct($client)
-    {
-        $this->client = $client;
-    }
+    public function __construct(protected HttpClientInterface $httpClient)
+    {}
 }

--- a/src/Service/AccountService.php
+++ b/src/Service/AccountService.php
@@ -6,7 +6,7 @@ class AccountService extends AbstractService
 {
     public function login($username, $password)
     {
-        return $this->client->post('accounts/login', [
+        return $this->httpClient->post('accounts/login', [
                 'username' => $username,
                 'password' => $password,
         ]);
@@ -14,7 +14,7 @@ class AccountService extends AbstractService
 
     public function create($username, $password)
     {
-        return $this->client->post('accounts', [
+        return $this->httpClient->post('accounts', [
                 'username' => $username,
                 'password' => $password,
         ]);
@@ -22,6 +22,6 @@ class AccountService extends AbstractService
 
     public function role($policyId, $roleType)
     {
-        return $this->client->post("policies/{$policyId}/role/{$roleType}");
+        return $this->httpClient->post("policies/{$policyId}/role/{$roleType}");
     }
 }

--- a/src/Service/MrvService.php
+++ b/src/Service/MrvService.php
@@ -4,44 +4,31 @@ namespace Dovu\GuardianPhpSdk\Service;
 
 class MrvService extends AbstractService
 {
-    /**
-     *
-     * @param string $policyId
-     * @param string $document
-     * @return void
-     */
+
     public function submitAgrecalcDocument(string $policyId, string $document)
     {
         if (! is_array($document)) {
             $document = json_decode($document, true);
         }
 
-        return $this->client->postJson("policies/{$policyId}/mrv/agrecalc", $document);
+        return $this->httpClient->post(uri: "policies/{$policyId}/mrv/agrecalc", payload: $document, jsonRequest: true);
     }
 
-    /**
-     *
-     * @param string $policyId
-     * @param string $document
-     * @return void
-     */
+
+
     public function submitCoolFarmToolDocument(string $policyId, string $document)
     {
         if (! is_array($document)) {
             $document = json_decode($document, true);
         }
 
-        return $this->client->postJson("policies/{$policyId}/mrv/cool-farm-tool", $document);
+        return $this->httpClient->post(uri: "policies/{$policyId}/mrv/cool-farm-tool", payload: $document, jsonRequest: true);
     }
 
-    /**
-     *
-     * @param [type] $policyId
-     * @param [type] $did
-     * @return void
-     */
-    public function approveMrvDocument($policyId, $did)
+
+    
+    public function approveMrvDocument(string $policyId, string $did)
     {
-        return $this->client->put("policies/{$policyId}/approve/mrv/{$did}");
+        return $this->httpClient->put("policies/{$policyId}/approve/mrv/{$did}");
     }
 }

--- a/src/Service/PolicyService.php
+++ b/src/Service/PolicyService.php
@@ -16,7 +16,7 @@ class PolicyService extends AbstractService
             $document = json_decode($document, true);
         }
 
-        return $this->client->postJson("policies/{$policyId}/register", $document);
+        return $this->httpClient->post(uri: "policies/{$policyId}/register", payload: $document, jsonRequest: true);
     }
 
     /**
@@ -27,7 +27,7 @@ class PolicyService extends AbstractService
      */
     public function approveApplication(string $policyId, string $did)
     {
-        return $this->client->put("policies/{$policyId}/approve/application/{$did}");
+        return $this->httpClient->put("policies/{$policyId}/approve/application/{$did}");
     }
 
     /**
@@ -42,7 +42,7 @@ class PolicyService extends AbstractService
             $document = json_decode($document, true);
         }
 
-        return $this->client->postJson("policies/{$policyId}/project", $document);
+        return $this->httpClient->post(uri: "policies/{$policyId}/project", payload: $document, jsonRequest: true);
     }
 
     /**
@@ -53,7 +53,7 @@ class PolicyService extends AbstractService
      */
     public function approveProject(string $policyId, string $did)
     {
-        return $this->client->put("policies/{$policyId}/approve/project/{$did}");
+        return $this->httpClient->put("policies/{$policyId}/approve/project/{$did}");
     }
 
     /**
@@ -67,7 +67,7 @@ class PolicyService extends AbstractService
             return [];
         }
 
-        return $this->client->get("policies/{$policyId}/trustchains");
+        return $this->httpClient->get("policies/{$policyId}/trustchains");
     }
 
     /**
@@ -77,6 +77,6 @@ class PolicyService extends AbstractService
      */
     public function token(string $policyId)
     {
-        return $this->client->get("policies/{$policyId}/token");
+        return $this->httpClient->get("policies/{$policyId}/token");
     }
 }

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -2,6 +2,8 @@
 
 namespace Dovu\GuardianPhpSdk\Service;
 
+use Dovu\GuardianPhpSdk\HttpClient\HttpClient;
+
 /**
  * Service factory class for API resources.
  *
@@ -39,7 +41,7 @@ class ServiceFactory extends AbstractServiceFactory
         $serviceClass = $this->getServiceClass($name);
 
         if ($serviceClass !== null) {
-            return new $serviceClass($this->client);
+            return new $serviceClass(new HttpClient($this->client));
         }
 
         trigger_error('Undefined property: ' . static::class . '::$' . $name);


### PR DESCRIPTION
I have updated the SDK to work better and have a basic notification system.

## Improvements

### 1. Notification system

Try / Catch is now in the HttpClient module, and therefore in only one place. This removes the impact of having try/catch all over the laravel code.

If an error is thrown, it returns the error but also sends the error to any channel that has been added. Currently there is only a Slack notifier, but adding others should be fairly straight forward. It should be noted this is not using Laravel notications so its indendant to be used in other frameworks etc..

To get notified by slack, first we need to get a webhook url from api.slack.com and create a webhook to the specific channels we want the error message to go to, then the webhook needs adding in to the .env file like below: 

`LOG_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxx`

The GuardianProvider.php file needs updating in laravel to add the slack notification as follows:

`$api->addNotification( ['slack' => config('logging.channels.slack.url')] );`

Notifications will be logged as below:

<img width="461" alt="Screenshot 2022-11-08 at 16 56 19" src="https://user-images.githubusercontent.com/35781789/200627585-699f5db4-ef8e-4360-bd23-d977ab4d827e.png">


### 2. HttpClient

I have removed all the fluent Http calls from the BaseAPIClient.php file - as much as i like the Spatie stuff, i'm not always in love with their coding style (I do love the packages and training they provide !!).

Given PHP 8.x has better coding exposure such as names arguments - its easy to see in the code what is being called, even if the parameters are boolean, so have used dependancy injection and polymorphism to pass objects along in a more OOP style.

All the HttpClient method calls are now in the HttpClient and the services (eg AccountService, MRVService) now call the httpclient directly. This has made the code a lot cleaner.

### 3. Hmac

Hmac now works as a singleton to remove some of the hard dependancy on httpclient.

### What else this means

Having decided to not use try / catches all over the place in the laravel code (I just hated that in the end), it keeps the laravel code the same for now. It could do with some organisational change but i think that can be added to the technical debt and be done at another time.


